### PR TITLE
changes to hunt religion

### DIFF
--- a/common/church_aspects/anb_dookan_abilities.txt
+++ b/common/church_aspects/anb_dookan_abilities.txt
@@ -22,6 +22,7 @@ gather_great_host_great_aspect = {
 	
 	trigger = {
 		NOT = { manpower_percentage = 1 }
+		NOT = { has_country_modifier = slackening_modifier }
 	}
 	
 	effect = {
@@ -49,6 +50,7 @@ gather_great_host_old_aspect = {
 	
 	trigger = {
 		NOT = { manpower_percentage = 1 }
+		NOT = { has_country_modifier = slackening_modifier }
 	}
 	
 	effect = {

--- a/common/church_aspects/anb_hunt_abilities.txt
+++ b/common/church_aspects/anb_hunt_abilities.txt
@@ -77,7 +77,7 @@ harpy_gain_siege_aspect = {
 
 harpy_move_pop_aspect = {
 	sprite = "GFX_gather_breeding_mates"
-	cost = 100
+	cost = 75
 	
 	potential = {
 		NOT = { has_country_flag = no_longer_monstrous }
@@ -106,7 +106,7 @@ harpy_move_pop_aspect = {
 	}
 	
 	ai_will_do = {
-		factor = 10
+		factor = 7
 		modifier = {
 			factor = 0
 			is_at_war = yes
@@ -180,7 +180,7 @@ harpy_entice_immigration_aspect = {
 	}
 	
 	ai_will_do = {
-		factor = 10
+		factor = 7
 		modifier = {
 			factor = 0
 			is_at_war = yes

--- a/common/event_modifiers/sebennar_modifiers.txt
+++ b/common/event_modifiers/sebennar_modifiers.txt
@@ -1,0 +1,1 @@
+harpy_roost_AI_cooldown = {}

--- a/common/scripted_effects/anb_scripted_effects.txt
+++ b/common/scripted_effects/anb_scripted_effects.txt
@@ -918,7 +918,7 @@ harpy_define_pop_to_take = {
 	}
 }
 
-harpy_move_pop_to_capital_effect = {
+harpy_move_pop_to_roost_effect = {
 	if = { limit = { has_elven_majority_trigger = yes }
 		ROOT = {
 			event_target:harpy_define_where = {

--- a/common/scripted_effects/anb_scripted_effects.txt
+++ b/common/scripted_effects/anb_scripted_effects.txt
@@ -921,7 +921,7 @@ harpy_define_pop_to_take = {
 harpy_move_pop_to_capital_effect = {
 	if = { limit = { has_elven_majority_trigger = yes }
 		ROOT = {
-			capital_scope = {
+			event_target:harpy_define_where = {
 				if = { limit = { has_large_elven_minority_trigger = yes }
 					random_list = {
 						33 = { add_base_tax = 1 }
@@ -937,7 +937,7 @@ harpy_move_pop_to_capital_effect = {
 	}
 	else_if = { limit = { has_orcish_majority_trigger = yes }
 		ROOT = {
-			capital_scope = {
+			event_target:harpy_define_where = {
 				if = { limit = { has_large_orcish_minority_trigger = yes }
 					random_list = {
 						33 = { add_base_tax = 1 }
@@ -953,7 +953,7 @@ harpy_move_pop_to_capital_effect = {
 	}
 	else_if = { limit = { has_ruinborn_majority_trigger = yes }
 		ROOT = {
-			capital_scope = {
+			event_target:harpy_define_where = {
 				if = { limit = { has_large_ruinborn_minority_trigger = yes }
 					random_list = {
 						33 = { add_base_tax = 1 }
@@ -969,7 +969,7 @@ harpy_move_pop_to_capital_effect = {
 	}
 	else_if = { limit = { has_goblin_majority_trigger = yes }
 		ROOT = {
-			capital_scope = {
+			event_target:harpy_define_where = {
 				if = { limit = { has_large_goblin_minority_trigger = yes }
 					random_list = {
 						33 = { add_base_tax = 1 }
@@ -985,7 +985,7 @@ harpy_move_pop_to_capital_effect = {
 	}
 	else_if = { limit = { has_hobgoblin_majority_trigger = yes }
 		ROOT = {
-			capital_scope = {
+			event_target:harpy_define_where = {
 				if = { limit = { has_large_hobgoblin_minority_trigger = yes }
 					random_list = {
 						33 = { add_base_tax = 1 }
@@ -1001,7 +1001,7 @@ harpy_move_pop_to_capital_effect = {
 	}
 	else_if = { limit = { has_human_majority_trigger = yes }
 		ROOT = {
-			capital_scope = {
+			event_target:harpy_define_where = {
 				if = { limit = { has_large_human_minority_trigger = yes }
 					random_list = {
 						33 = { add_base_tax = 1 }
@@ -1016,9 +1016,9 @@ harpy_move_pop_to_capital_effect = {
 		}
 	}
 	random_list = {
-		33 = { add_base_tax = -1 ROOT = { capital_scope = { add_base_tax = 1 } } }
-		33 = { add_base_production = -1 ROOT = { capital_scope = { add_base_production = 1 } } }
-		33 = { add_base_manpower = -1 ROOT = { capital_scope = { add_base_manpower = 1 } } }
+		33 = { add_base_tax = -1 ROOT = { event_target:harpy_define_where = { add_base_tax = 1 } } }
+		33 = { add_base_production = -1 ROOT = { event_target:harpy_define_where = { add_base_production = 1 } } }
+		33 = { add_base_manpower = -1 ROOT = { event_target:harpy_define_where = { add_base_manpower = 1 } } }
 	}
 	if = {
 		limit = { NOT = { owned_by = ROOT } }

--- a/decisions/HarpyDecisions.txt
+++ b/decisions/HarpyDecisions.txt
@@ -5,33 +5,42 @@ country_decisions = {
 		potential = {
 			has_country_modifier = harpy_administration
 			NOT = { has_country_flag = open_harpy_roost_menu }
+			NOT = { has_country_flag = harpy_roost_AI_cooldown }
 		}
 		major = yes
 		
 		allow = {
 			adm_power = 50
-			has_country_modifier = harpy_military
-			any_owned_province = {
-				fort_level = 1
-				is_city = yes
-				NOT = { has_province_modifier = harpy_roost }
-				OR = {
-					has_terrain = mountain
-					has_terrain = highlands
-					has_terrain = hills
-				}
-			}
+		#	has_country_modifier = harpy_military
+		#	any_owned_province = {
+		#		fort_level = 1
+		#		is_city = yes
+		#		NOT = { has_province_modifier = harpy_roost }
+		#		OR = {
+		#			has_terrain = mountain
+		#			has_terrain = highlands
+		#			has_terrain = hills
+		#		}
+		#	}
 			NOT = {
 				any_owned_province = {
 					has_province_modifier = harpy_roost_under_construction
 				}
 			}
-			can_build_roost = yes
+		#	can_build_roost = yes
 		}
 	
 		effect = {
 			add_adm_power = -50
 			country_event = { id = harpy_events.1 }
+			if {
+				AI = yes
+				add_country_modifier = {
+				name = harpy_roost_AI_cooldown 
+				duration = 1825
+				hidden = yes
+				}
+			}
 		}
 		ai_will_do = {
 			factor = 1

--- a/decisions/HarpyDecisions.txt
+++ b/decisions/HarpyDecisions.txt
@@ -5,7 +5,7 @@ country_decisions = {
 		potential = {
 			has_country_modifier = harpy_administration
 			NOT = { has_country_flag = open_harpy_roost_menu }
-			NOT = { has_country_flag = harpy_roost_AI_cooldown }
+			NOT = { has_country_modifier = harpy_roost_AI_cooldown }
 		}
 		major = yes
 		
@@ -22,11 +22,11 @@ country_decisions = {
 		#			has_terrain = hills
 		#		}
 		#	}
-			NOT = {
-				any_owned_province = {
-					has_province_modifier = harpy_roost_under_construction
-				}
-			}
+		#	NOT = {
+		#		any_owned_province = {
+		#			has_province_modifier = harpy_roost_under_construction
+		#		}
+		#	}
 		#	can_build_roost = yes
 		}
 	

--- a/decisions/HarpyDecisions.txt
+++ b/decisions/HarpyDecisions.txt
@@ -37,7 +37,7 @@ country_decisions = {
 				AI = yes
 				add_country_modifier = {
 				name = harpy_roost_AI_cooldown 
-				duration = 1825
+				duration = 3650
 				hidden = yes
 				}
 			}

--- a/events/HarpyEvents.txt
+++ b/events/HarpyEvents.txt
@@ -39,7 +39,11 @@ country_event = {
 					has_terrain = hills
 				}
 				NOT = { has_province_modifier = harpy_roost }
-				NOT = { has_province_modifier = harpy_roost_under_construction }
+				NOT = {
+					any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}
 			}
 		}
 		goto = capital_scope
@@ -57,6 +61,11 @@ country_event = {
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region1
+			NOT = {
+				any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}
 		}
 		goto = harpy_roost_region1
 		
@@ -70,6 +79,11 @@ country_event = {
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region2
+			NOT = {
+				any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}		
 		}
 		goto = harpy_roost_region2
 		
@@ -83,6 +97,11 @@ country_event = {
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region3
+			NOT = {
+				any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}			
 		}
 		goto = harpy_roost_region3
 		
@@ -96,6 +115,11 @@ country_event = {
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region4
+						NOT = {
+				any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}
 		}
 		goto = harpy_roost_region4
 		
@@ -109,6 +133,11 @@ country_event = {
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region5
+						NOT = {
+				any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}
 		}
 		goto = harpy_roost_region5
 		
@@ -122,6 +151,11 @@ country_event = {
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region6
+						NOT = {
+				any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}
 		}
 		goto = harpy_roost_region6
 		
@@ -135,6 +169,11 @@ country_event = {
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region7
+						NOT = {
+				any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}
 		}
 		goto = harpy_roost_region7
 		
@@ -148,6 +187,11 @@ country_event = {
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region8
+						NOT = {
+				any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}
 		}
 		goto = harpy_roost_region8
 		
@@ -161,6 +205,11 @@ country_event = {
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region9
+						NOT = {
+				any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}
 		}
 		goto = harpy_roost_region9
 		
@@ -176,6 +225,11 @@ country_event = {
 			has_saved_event_target = harpy_roost_region10
 		}
 		goto = harpy_roost_region10
+					NOT = {
+				any_owned_province = {
+					has_province_modifier = harpy_roost_under_construction
+					}
+				}
 		
 		hidden_effect = {
 			event_target:harpy_roost_region10 = { province_event = { id = harpy_events.2 } }

--- a/events/HarpyEvents.txt
+++ b/events/HarpyEvents.txt
@@ -26,7 +26,7 @@ country_event = {
 	
 	option = { #build in capital
 		name = harpy_events.1.a
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 100 }
 		trigger = {
 			can_build_roost = yes
 			capital_scope = {
@@ -53,7 +53,7 @@ country_event = {
 	}
 	option = { #build in region 1
 		name = harpy_events.1.b
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region1
@@ -66,7 +66,7 @@ country_event = {
 	}
 	option = { #build in region 2
 		name = harpy_events.1.c
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region2
@@ -79,7 +79,7 @@ country_event = {
 	}
 	option = { #build in region 3
 		name = harpy_events.1.dd
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region3
@@ -92,7 +92,7 @@ country_event = {
 	}
 	option = { #build in region 4
 		name = harpy_events.1.e
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region4
@@ -105,7 +105,7 @@ country_event = {
 	}
 	option = { #build in region 5
 		name = harpy_events.1.f
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region5
@@ -118,7 +118,7 @@ country_event = {
 	}
 	option = { #build in region 6
 		name = harpy_events.1.g
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region6
@@ -131,7 +131,7 @@ country_event = {
 	}
 	option = { #build in region 7
 		name = harpy_events.1.h
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region7
@@ -144,7 +144,7 @@ country_event = {
 	}
 	option = { #build in region 8
 		name = harpy_events.1.i
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region8
@@ -157,7 +157,7 @@ country_event = {
 	}
 	option = { #build in region 9
 		name = harpy_events.1.j
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region9
@@ -170,7 +170,7 @@ country_event = {
 	}
 	option = { #build in region 10
 		name = harpy_events.1.k
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			can_build_roost = yes
 			has_saved_event_target = harpy_roost_region10
@@ -214,7 +214,7 @@ province_event = {
 	
 	option = {
 		name = harpy_events.2.a
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			has_saved_event_target = harpy_roost1
 			event_target:harpy_roost1 = { has_province_flag = harpy_roost_@PREV }
@@ -238,7 +238,7 @@ province_event = {
 	}
 	option = {
 		name = harpy_events.2.b
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			has_saved_event_target = harpy_roost2
 			event_target:harpy_roost2 = { has_province_flag = harpy_roost_@PREV }
@@ -262,7 +262,7 @@ province_event = {
 	}
 	option = {
 		name = harpy_events.2.c
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			has_saved_event_target = harpy_roost3
 			event_target:harpy_roost3 = { has_province_flag = harpy_roost_@PREV }
@@ -286,7 +286,7 @@ province_event = {
 	}
 	option = {
 		name = harpy_events.2.dd
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			has_saved_event_target = harpy_roost4
 			event_target:harpy_roost4 = { has_province_flag = harpy_roost_@PREV }
@@ -310,7 +310,7 @@ province_event = {
 	}
 	option = {
 		name = harpy_events.2.e
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			has_saved_event_target = harpy_roost5
 			event_target:harpy_roost5 = { has_province_flag = harpy_roost_@PREV }
@@ -334,7 +334,7 @@ province_event = {
 	}
 	option = {
 		name = harpy_events.2.f
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			has_saved_event_target = harpy_roost6
 			event_target:harpy_roost6 = { has_province_flag = harpy_roost_@PREV }
@@ -358,7 +358,7 @@ province_event = {
 	}
 	option = {
 		name = harpy_events.2.g
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			has_saved_event_target = harpy_roost7
 			event_target:harpy_roost7 = { has_province_flag = harpy_roost_@PREV }
@@ -382,7 +382,7 @@ province_event = {
 	}
 	option = {
 		name = harpy_events.2.h
-        ai_chance = { factor = 1 }
+        ai_chance = { factor = 10 }
 		trigger = {
 			has_saved_event_target = harpy_roost8
 			event_target:harpy_roost8 = { has_province_flag = harpy_roost_@PREV }

--- a/events/The_Hunt_events.txt
+++ b/events/The_Hunt_events.txt
@@ -44,7 +44,7 @@ country_event = {
 						fort_level = 1 
 						is_capital = YES
 					}
-					save_event_target_as = harpy_define_WHERE
+					save_event_target_as = harpy_define_where
 					}
 			}
 		every_owned_province = {
@@ -56,7 +56,7 @@ country_event = {
 						is_capital = YES
 					}
 					NOT = { 
-							higher_development_than = harpy_define_WHERE
+							higher_development_than = harpy_define_where
 						}
 					}
 					save_event_target_as = harpy_define_where

--- a/events/The_Hunt_events.txt
+++ b/events/The_Hunt_events.txt
@@ -41,15 +41,29 @@ country_event = {
 					has_province_modifier = harpy_roost
 					has_harpy_majority_trigger = yes
 					OR = {
-						fort_level = 1 
+						has_fort_building_trigger = yes 
 						is_capital = YES
 					}
 					save_event_target_as = harpy_define_where
 					}
 			}
-	}
-	}
-	}
+		every_owned_province = {
+				limit = {
+					has_province_modifier = harpy_roost
+					has_harpy_majority_trigger = yes
+					OR = {
+						has_fort_building_trigger = yes 
+						is_capital = YES
+					}
+					NOT = { 
+							higher_development_than = harpy_define_where
+						}
+					}
+					save_event_target_as = harpy_define_where
+				}
+			}
+		}
+		}
 	
 	
 	after = {

--- a/events/The_Hunt_events.txt
+++ b/events/The_Hunt_events.txt
@@ -81,7 +81,7 @@ country_event = {
 		trigger = { has_saved_event_target = harpy_pop1 }
 		goto = harpy_pop1
 		event_target:harpy_pop1 = {
-			harpy_move_pop_to_capital_effect = yes
+		harpy_move_pop_to_roost_effect = yes
 		}
 	}
 	option = {
@@ -90,7 +90,7 @@ country_event = {
 		trigger = { has_saved_event_target = harpy_pop2 }
 		goto = harpy_pop2
 		event_target:harpy_pop2 = {
-			harpy_move_pop_to_capital_effect = yes
+		harpy_move_pop_to_roost_effect = yes
 		}
 	}
 	option = {
@@ -99,7 +99,7 @@ country_event = {
 		trigger = { has_saved_event_target = harpy_pop3 }
 		goto = harpy_pop3
 		event_target:harpy_pop3 = {
-			harpy_move_pop_to_capital_effect = yes
+		harpy_move_pop_to_roost_effect = yes
 		}
 	}
 	option = {
@@ -108,7 +108,7 @@ country_event = {
 		trigger = { has_saved_event_target = harpy_pop4 }
 		goto = harpy_pop4
 		event_target:harpy_pop4 = {
-			harpy_move_pop_to_capital_effect = yes
+		harpy_move_pop_to_roost_effect = yes
 		}
 	}
 	option = {
@@ -117,7 +117,7 @@ country_event = {
 		trigger = { has_saved_event_target = harpy_pop5 }
 		goto = harpy_pop5
 		event_target:harpy_pop5 = {
-			harpy_move_pop_to_capital_effect = yes
+		harpy_move_pop_to_roost_effect = yes
 		}
 	}
 	option = {
@@ -584,7 +584,7 @@ country_event = {
 		trigger = { has_saved_event_target = harpy_pop1 }
 		goto = harpy_pop1
 		event_target:harpy_pop1 = {
-			harpy_move_pop_to_capital_effect = yes
+		harpy_move_pop_to_roost_effect = yes
 		}
 	}
 	option = {
@@ -593,7 +593,7 @@ country_event = {
 		trigger = { has_saved_event_target = harpy_pop2 }
 		goto = harpy_pop2
 		event_target:harpy_pop2 = {
-			harpy_move_pop_to_capital_effect = yes
+		harpy_move_pop_to_roost_effect = yes
 		}
 	}
 	option = {
@@ -602,7 +602,7 @@ country_event = {
 		trigger = { has_saved_event_target = harpy_pop3 }
 		goto = harpy_pop3
 		event_target:harpy_pop3 = {
-			harpy_move_pop_to_capital_effect = yes
+		harpy_move_pop_to_roost_effect = yes
 		}
 	}
 	option = {
@@ -611,7 +611,7 @@ country_event = {
 		trigger = { has_saved_event_target = harpy_pop4 }
 		goto = harpy_pop4
 		event_target:harpy_pop4 = {
-			harpy_move_pop_to_capital_effect = yes
+		harpy_move_pop_to_roost_effect = yes
 		}
 	}
 	option = {
@@ -620,7 +620,7 @@ country_event = {
 		trigger = { has_saved_event_target = harpy_pop5 }
 		goto = harpy_pop5
 		event_target:harpy_pop5 = {
-			harpy_move_pop_to_capital_effect = yes
+		harpy_move_pop_to_roost_effect = yes
 		}
 	}
 	option = {

--- a/events/The_Hunt_events.txt
+++ b/events/The_Hunt_events.txt
@@ -47,23 +47,9 @@ country_event = {
 					save_event_target_as = harpy_define_where
 					}
 			}
-		every_owned_province = {
-				limit = {
-					has_province_modifier = harpy_roost
-					has_harpy_majority_trigger = yes
-					OR = {
-						fort_level = 1 
-						is_capital = YES
-					}
-					NOT = { 
-							higher_development_than = harpy_define_where
-						}
-					}
-					save_event_target_as = harpy_define_where
-				}
-			}
-		}
-		}
+	}
+	}
+	}
 	
 	
 	after = {

--- a/events/The_Hunt_events.txt
+++ b/events/The_Hunt_events.txt
@@ -56,7 +56,7 @@ country_event = {
 						is_capital = YES
 					}
 					NOT = { 
-							higher_development_than = harpy_define_where
+							higher_development_than = event_target:harpy_define_where
 						}
 					}
 					save_event_target_as = harpy_define_where

--- a/events/The_Hunt_events.txt
+++ b/events/The_Hunt_events.txt
@@ -23,6 +23,7 @@ country_event = {
 }
 
 #Move pop
+	desc = harpy_events.1.d
 country_event = {
 	id = the_hunt_events.2
 	title = the_hunt_events.2.t
@@ -30,12 +31,40 @@ country_event = {
 	picture = FAMINE_eventPicture
 	
 	is_triggered_only = yes
-	
+	#todo make less ugly tooltip (at least now it shows true behaviour)
 	immediate = {
 		hidden_effect = {
 			harpy_define_pop_to_take = yes
+				ROOT = {
+			random_owned_province = {
+				limit = {
+					has_province_modifier = harpy_roost
+					has_harpy_majority_trigger = yes
+					OR = {
+						fort_level = 1 
+						is_capital = YES
+					}
+					save_event_target_as = harpy_define_WHERE
+					}
+			}
+		every_owned_province = {
+				limit = {
+					has_province_modifier = harpy_roost
+					has_harpy_majority_trigger = yes
+					OR = {
+						fort_level = 1 
+						is_capital = YES
+					}
+					NOT = { 
+							higher_development_than = harpy_define_WHERE
+						}
+					}
+					save_event_target_as = harpy_define_where
+				}
+			}
 		}
-	}
+		}
+	
 	
 	after = {
 		hidden_effect = {
@@ -280,14 +309,28 @@ country_event = {
 		name = the_hunt_events.4.a
         ai_chance = { factor = 100 }
 		custom_tooltip = harpy_egg_effect_tt
+		#todo calc chance, maybe adjust chance
 		tooltip = {
+			if = { 
+			has_country_modifier = the_hunt_myna_modifier 
 			random_list = {
+				
+				24 = { add_country_modifier = { name = harpy_egg_merchant duration = 9125 desc = harpy_25_years_tt } }
+				24 = { add_country_modifier = { name = harpy_egg_diplomat duration = 9125 desc = harpy_25_years_tt } }
+				24 = { custom_tooltip = harpy_get_random_advisor_tt }
+				14 = { create_general = { tradition = 50 } }
+				14 = { create_war_wizard_effect = yes }
+			}
+			}
+			else_if = {
+			radnom_list = {
 				20 = { add_country_modifier = { name = harpy_egg_merchant duration = 9125 desc = harpy_25_years_tt } }
 				20 = { add_country_modifier = { name = harpy_egg_diplomat duration = 9125 desc = harpy_25_years_tt } }
 				20 = { add_country_modifier = { name = harpy_egg_missionary duration = 9125 desc = harpy_25_years_tt } }
 				20 = { custom_tooltip = harpy_get_random_advisor_tt }
 				10 = { create_general = { tradition = 50 } }
 				10 = { create_war_wizard_effect = yes }
+			}
 			}
 		}
 		hidden_effect = { country_event = { id = the_hunt_events.6 days = 9125 } }
@@ -307,7 +350,20 @@ country_event = {
 		}
 		
 		custom_tooltip = harpy_egg_effect_tt
+		#todo calc chance, maybe adjust chance
 		tooltip = {
+			if = {
+				has_country_modifier = the_hunt_myna_modifier
+				random_list = {
+				18 = { add_country_modifier = { name = harpy_egg_merchant duration = 9125 desc = harpy_25_years_tt } }
+				18 = { add_country_modifier = { name = harpy_egg_diplomat duration = 9125 desc = harpy_25_years_tt } }
+				#15 = { add_country_modifier = { name = harpy_egg_missionary duration = 9125 desc = harpy_25_years_tt } }
+				18 = { custom_tooltip = harpy_get_random_advisor_tt }
+				13 = { create_general = { tradition = 50 } }
+				33 = { create_war_wizard_effect = yes }
+			}
+			}
+			else_if {
 			random_list = {
 				15 = { add_country_modifier = { name = harpy_egg_merchant duration = 9125 desc = harpy_25_years_tt } }
 				15 = { add_country_modifier = { name = harpy_egg_diplomat duration = 9125 desc = harpy_25_years_tt } }
@@ -315,6 +371,7 @@ country_event = {
 				15 = { custom_tooltip = harpy_get_random_advisor_tt }
 				10 = { create_general = { tradition = 50 } }
 				30 = { create_war_wizard_effect = yes }
+			}
 			}
 		}
 		hidden_effect = { country_event = { id = the_hunt_events.6 days = 9125 } }
@@ -331,6 +388,18 @@ country_event = {
 		tooltip = { add_church_power = -100 }
 		custom_tooltip = harpy_egg_effect_tt
 		tooltip = {
+			if = {
+				has_country_modifier = the_hunt_myna_modifier
+				random_list = {
+				18 = { add_country_modifier = { name = harpy_egg_merchant duration = 9125 desc = harpy_25_years_tt } }
+				18 = { add_country_modifier = { name = harpy_egg_diplomat duration = 9125 desc = harpy_25_years_tt } }
+				#15 = { add_country_modifier = { name = harpy_egg_missionary duration = 9125 desc = harpy_25_years_tt } }
+				18 = { custom_tooltip = harpy_get_random_advisor_tt }
+				13 = { create_general = { tradition = 50 } }
+				33 = { create_war_wizard_effect = yes }
+			}
+			}
+			else_if {
 			random_list = {
 				15 = { add_country_modifier = { name = harpy_egg_merchant duration = 9125 desc = harpy_25_years_tt } }
 				15 = { add_country_modifier = { name = harpy_egg_diplomat duration = 9125 desc = harpy_25_years_tt } }
@@ -338,6 +407,7 @@ country_event = {
 				15 = { custom_tooltip = harpy_get_random_advisor_tt }
 				10 = { create_general = { tradition = 50 } }
 				30 = { create_war_wizard_effect = yes }
+			}
 			}
 		}
 		hidden_effect = { country_event = { id = the_hunt_events.5 } }
@@ -406,6 +476,7 @@ country_event = {
 		ai_chance = {
 			factor = 20
 			modifier = { factor = 0.75 has_country_flag = harpy_egg_magical }
+			modifier = { factor = 0 has_country_modifier = the_hunt_myna_modifier }
 		}
 		set_country_flag = harpy_egg_result_advisor
 	}


### PR DESCRIPTION
Changed hunt religion.
move pop instead to capital moves to roost targeting lower dev roosts first, also lowered it cost to 75 from 100 (also adjusted AI weight on that to reflect cost change)
myna prevents getting missionaries from powerfull egg power.
changes yet to be tested do not merge